### PR TITLE
Call unref on handle

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -73,6 +73,7 @@ class Cache {
     // We then create a new timeout function for
     // the new value.
     const handle = setTimeout(() => this.remove(key), ttl);
+    handle.unref();
   
     // And we save the value into the cache storage
     // with the handle.


### PR DESCRIPTION
Stop the timeout from keeping the NodeJS event loop active.